### PR TITLE
Possibility to change download directory name and fix isolatedLoad with an id

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Changes in this fork
 
+### Version 1.1.0
+
 * Libraries can be loaded from an `IsolatedClassLoader`
     * Use `LibraryManager.getIsolatedClassLoaderOf(...)` to get the `IsolatedClassLoader` via its `id`
     * Use `Library.id(...)` to set an ID to the library
@@ -10,6 +12,11 @@
 * Support for Java 9+ Modules to prevent deprecations
 * Distribution management to repo.alessiodp.com
 
+### Version 1.1.1
+
+* Download directory name can now be changed when instantiating the LibraryManager
+* When loading a library with `Library.isolatedLoad(true).id(aId)` and an IsolatedClassLoader with id `aId` is present
+  it will be used instead of creating a new one
 
 # Libby 
 

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>libby-bukkit</artifactId>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bukkit/src/main/java/net/byteflux/libby/BukkitLibraryManager.java
+++ b/bukkit/src/main/java/net/byteflux/libby/BukkitLibraryManager.java
@@ -24,7 +24,17 @@ public class BukkitLibraryManager extends LibraryManager {
      * @param plugin the plugin to manage
      */
     public BukkitLibraryManager(Plugin plugin) {
-        super(new JDKLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath());
+        this(plugin, "lib");
+    }
+
+    /**
+     * Creates a new Bukkit library manager.
+     *
+     * @param plugin the plugin to manage
+     * @param directoryName download directory name
+     */
+    public BukkitLibraryManager(Plugin plugin, String directoryName) {
+        super(new JDKLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath(), directoryName);
         classLoader = new URLClassLoaderHelper((URLClassLoader) plugin.getClass().getClassLoader());
     }
 

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>libby-bungee</artifactId>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.16-R0.4-SNAPSHOT</version>
+            <version>1.16-R0.5-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bungee/src/main/java/net/byteflux/libby/BungeeLibraryManager.java
+++ b/bungee/src/main/java/net/byteflux/libby/BungeeLibraryManager.java
@@ -24,7 +24,17 @@ public class BungeeLibraryManager extends LibraryManager {
      * @param plugin the plugin to manage
      */
     public BungeeLibraryManager(Plugin plugin) {
-        super(new JDKLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath());
+        this(plugin, "lib");
+    }
+
+    /**
+     * Creates a new Bungee library manager.
+     *
+     * @param plugin the plugin to manage
+     * @param directoryName download directory name
+     */
+    public BungeeLibraryManager(Plugin plugin, String directoryName) {
+        super(new JDKLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath(), directoryName);
         classLoader = new URLClassLoaderHelper((URLClassLoader) plugin.getClass().getClassLoader());
     }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>libby-core</artifactId>

--- a/core/src/main/java/net/byteflux/libby/LibraryManager.java
+++ b/core/src/main/java/net/byteflux/libby/LibraryManager.java
@@ -96,13 +96,19 @@ public abstract class LibraryManager {
 
     /**
      * Adds a file to the isolated class loader
+     *
      * @param library the library to add
      * @param file the file to add
      */
     protected void addToIsolatedClasspath(Library library, Path file) {
-        IsolatedClassLoader classLoader = new IsolatedClassLoader();
+        IsolatedClassLoader classLoader;
+        String id = library.getId();
+        if (id != null) {
+            classLoader = isolatedLibraries.computeIfAbsent(id, s -> new IsolatedClassLoader());
+        } else {
+            classLoader = new IsolatedClassLoader();
+        }
         classLoader.addPath(file);
-        isolatedLibraries.put(library.getId(), classLoader);
     }
 
     /**

--- a/core/src/main/java/net/byteflux/libby/LibraryManager.java
+++ b/core/src/main/java/net/byteflux/libby/LibraryManager.java
@@ -88,6 +88,18 @@ public abstract class LibraryManager {
     }
 
     /**
+     * Creates a new library manager.
+     *
+     * @param logAdapter    plugin logging adapter
+     * @param dataDirectory plugin's data directory
+     * @param directoryName download directory name
+     */
+    protected LibraryManager(LogAdapter logAdapter, Path dataDirectory, String directoryName) {
+        logger = new Logger(requireNonNull(logAdapter, "logAdapter"));
+        saveDirectory = requireNonNull(dataDirectory, "dataDirectory").toAbsolutePath().resolve(requireNonNull(directoryName, "directoryName"));
+    }
+
+    /**
      * Adds a file to the plugin's classpath.
      *
      * @param file the file to add

--- a/core/src/main/java/net/byteflux/libby/LibraryManager.java
+++ b/core/src/main/java/net/byteflux/libby/LibraryManager.java
@@ -81,7 +81,10 @@ public abstract class LibraryManager {
      *
      * @param logAdapter    plugin logging adapter
      * @param dataDirectory plugin's data directory
+     *
+     * @deprecated Use {@link LibraryManager#LibraryManager(LogAdapter, Path, String)}
      */
+    @Deprecated
     protected LibraryManager(LogAdapter logAdapter, Path dataDirectory) {
         logger = new Logger(requireNonNull(logAdapter, "logAdapter"));
         saveDirectory = requireNonNull(dataDirectory, "dataDirectory").toAbsolutePath().resolve("lib");

--- a/nukkit/pom.xml
+++ b/nukkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>libby-nukkit</artifactId>

--- a/nukkit/src/main/java/net/byteflux/libby/NukkitLibraryManager.java
+++ b/nukkit/src/main/java/net/byteflux/libby/NukkitLibraryManager.java
@@ -24,7 +24,17 @@ public class NukkitLibraryManager extends LibraryManager {
      * @param plugin the plugin to manage
      */
     public NukkitLibraryManager(Plugin plugin) {
-        super(new NukkitLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath());
+        this(plugin, "lib");
+    }
+
+    /**
+     * Creates a new Nukkit library manager.
+     *
+     * @param plugin the plugin to manage
+     * @param directoryName download directory name
+     */
+    public NukkitLibraryManager(Plugin plugin, String directoryName) {
+        super(new NukkitLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath(), directoryName);
         classLoader = new URLClassLoaderHelper((URLClassLoader) plugin.getClass().getClassLoader());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.byteflux</groupId>
     <artifactId>libby</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/slf4j/pom.xml
+++ b/slf4j/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>libby-slf4j</artifactId>

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>libby-sponge</artifactId>

--- a/sponge/src/main/java/net/byteflux/libby/SpongeLibraryManager.java
+++ b/sponge/src/main/java/net/byteflux/libby/SpongeLibraryManager.java
@@ -29,7 +29,20 @@ public class SpongeLibraryManager<T> extends LibraryManager {
      */
     @Inject
     private SpongeLibraryManager(Logger logger, @ConfigDir(sharedRoot = false) Path dataDirectory, T plugin) {
-        super(new SLF4JLogAdapter(logger), dataDirectory);
+        this(logger, dataDirectory, plugin, "lib");
+    }
+
+    /**
+     * Creates a new Sponge library manager.
+     *
+     * @param logger        the plugin logger
+     * @param dataDirectory plugin's data directory
+     * @param plugin        the plugin to manage
+     * @param directoryName download directory name
+     */
+    @Inject
+    private SpongeLibraryManager(Logger logger, @ConfigDir(sharedRoot = false) Path dataDirectory, T plugin, String directoryName) {
+        super(new SLF4JLogAdapter(logger), dataDirectory, directoryName);
         classLoader = new URLClassLoaderHelper((URLClassLoader) requireNonNull(plugin, "plugin").getClass().getClassLoader());
     }
 

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>libby-velocity</artifactId>

--- a/velocity/src/main/java/net/byteflux/libby/VelocityLibraryManager.java
+++ b/velocity/src/main/java/net/byteflux/libby/VelocityLibraryManager.java
@@ -39,7 +39,26 @@ public class VelocityLibraryManager<T> extends LibraryManager {
                                    PluginManager pluginManager,
                                    T plugin) {
 
-        super(new SLF4JLogAdapter(logger), dataDirectory);
+        this(logger, dataDirectory, pluginManager, plugin, "lib");
+    }
+
+    /**
+     * Creates a new Velocity library manager.
+     *
+     * @param logger        the plugin logger
+     * @param dataDirectory plugin's data directory
+     * @param pluginManager Velocity plugin manager
+     * @param plugin        the plugin to manage
+     * @param directoryName download directory name
+     */
+    @Inject
+    private VelocityLibraryManager(Logger logger,
+                                   @DataDirectory Path dataDirectory,
+                                   PluginManager pluginManager,
+                                   T plugin,
+                                   String directoryName) {
+
+        super(new SLF4JLogAdapter(logger), dataDirectory, directoryName);
         this.pluginManager = requireNonNull(pluginManager, "pluginManager");
         this.plugin = requireNonNull(plugin, "plugin");
     }


### PR DESCRIPTION
This adds the possibility to change the name of the download directory.
This also fixes an issue where loading a library with an IsolatedClassLoader and an id will create every time a new IsolatedClassLoader, even if an IsolatedClassLoader with the same id is already present.

Also bump version to 1.1.1