### PR TITLE
Fixed a bug with the ClassLoader

### DIFF
--- a/core/src/main/java/net/byteflux/libby/classloader/CustomClassLoader.java
+++ b/core/src/main/java/net/byteflux/libby/classloader/CustomClassLoader.java
@@ -1,0 +1,15 @@
+package net.byteflux.libby.classloader;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class CustomClassLoader extends URLClassLoader {
+
+    public CustomClassLoader(URL[] urls, ClassLoader parent) {
+        super(urls, parent);
+    }
+
+    public void addURL(URL url) {
+        super.addURL(url);
+    }
+}


### PR DESCRIPTION
- Fixed a bug with the ClassLoader causing an InaccessibleObjectException in Java 16
- Replaced reflection with a custom implementation of a URLClassLoader which includes a public addURL method referencing the protected one.