### PR TITLE
Add support to relocation of libraries compiled with Java 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@
 * When loading a library with `Library.isolatedLoad(true).id(aId)` and an IsolatedClassLoader with id `aId` is present
   it will be used instead of creating a new one
 
+### Version 1.1.2
+
+* Add support for libraries compiled with Java 16
+* Updated libraries used by Libby
+
 # Libby 
 
 A runtime dependency management library for plugins running in Java-based Minecraft

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
     <artifactId>libby-bukkit</artifactId>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <version>1.17.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
     <artifactId>libby-bungee</artifactId>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.16-R0.5-SNAPSHOT</version>
+            <version>1.17-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
     <artifactId>libby-core</artifactId>

--- a/core/src/main/java/net/byteflux/libby/relocation/RelocationHelper.java
+++ b/core/src/main/java/net/byteflux/libby/relocation/RelocationHelper.java
@@ -52,8 +52,8 @@ public class RelocationHelper {
             Library.builder()
                    .groupId("org.ow2.asm")
                    .artifactId("asm-commons")
-                   .version("7.1")
-                   .checksum("5VkEidjxmE2Fv+q9Oxc3TFnCiuCdSOxKDrvQGVns01g=")
+                   .version("9.2")
+                   .checksum("vkzlMTiiOLtSLNeBz5Hzulzi9sqT7GLUahYqEnIl4KY=")
                    .build()
         ));
 
@@ -62,8 +62,8 @@ public class RelocationHelper {
             Library.builder()
                    .groupId("org.ow2.asm")
                    .artifactId("asm")
-                   .version("7.1")
-                   .checksum("SrL6K20sycyx6qBeoynEB7R7E+0pFfYvjEuMyWJY1N4=")
+                   .version("9.2")
+                   .checksum("udT+TXGTjfOIOfDspCqqpkz4sxPWeNoDbwyzyhmbR/U=")
                    .build()
         ));
 
@@ -72,8 +72,8 @@ public class RelocationHelper {
             Library.builder()
                    .groupId("me.lucko")
                    .artifactId("jar-relocator")
-                   .version("1.4")
-                   .checksum("1RsiF3BiVztjlfTA+svDCuoDSGFuSpTZYHvUK8yBx8I=")
+                   .version("1.5")
+                   .checksum("0D6eM99gKpEYFNDydgnto3Df0ygZGdRVqy5ahtj0oIs=")
                    .build()
         ));
 

--- a/nukkit/pom.xml
+++ b/nukkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
     <artifactId>libby-nukkit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.byteflux</groupId>
     <artifactId>libby</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/slf4j/pom.xml
+++ b/slf4j/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
     <artifactId>libby-slf4j</artifactId>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.32</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
     <artifactId>libby-sponge</artifactId>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.spongepowered</groupId>
             <artifactId>spongeapi</artifactId>
-            <version>7.2.0</version>
+            <version>7.3.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
 
     <artifactId>libby-velocity</artifactId>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
-            <version>1.1.2</version>
+            <version>3.0.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This updates the jar-relocator version to support relocations of libraries compiled with Java 16.
Also bump version to 1.1.2 and update libraries used by Libby to their latest version.