### PR TITLE
Add per-library repositories

### DIFF
--- a/core/src/main/java/net/byteflux/libby/Library.java
+++ b/core/src/main/java/net/byteflux/libby/Library.java
@@ -23,6 +23,11 @@ public class Library {
     private final Collection<String> urls;
 
     /**
+     * Repository URLs for this library
+     */
+    private final Collection<String> repositories;
+
+    /**
      * Library id (used by Isolated Class Loaders)
      */
     private final String id;
@@ -75,16 +80,45 @@ public class Library {
     /**
      * Creates a new library.
      *
-     * @param urls        direct download URLs
-     * @param id          library ID
-     * @param groupId     Maven group ID
-     * @param artifactId  Maven artifact ID
-     * @param version     artifact version
-     * @param classifier  artifact classifier or null
-     * @param checksum    binary SHA-256 checksum or null
-     * @param relocations jar relocations or null
+     * @param urls         direct download URLs
+     * @param id           library ID
+     * @param groupId      Maven group ID
+     * @param artifactId   Maven artifact ID
+     * @param version      artifact version
+     * @param classifier   artifact classifier or null
+     * @param checksum     binary SHA-256 checksum or null
+     * @param relocations  jar relocations or null
+     * @param isolatedLoad isolated load for this library
      */
     private Library(Collection<String> urls,
+                    String id,
+                    String groupId,
+                    String artifactId,
+                    String version,
+                    String classifier,
+                    byte[] checksum,
+                    Collection<Relocation> relocations,
+                    boolean isolatedLoad) {
+
+        this(urls, null, id, groupId, artifactId, version, classifier, checksum, relocations, isolatedLoad);
+    }
+
+    /**
+     * Creates a new library.
+     *
+     * @param urls         direct download URLs
+     * @param repositories repository URLs
+     * @param id           library ID
+     * @param groupId      Maven group ID
+     * @param artifactId   Maven artifact ID
+     * @param version      artifact version
+     * @param classifier   artifact classifier or null
+     * @param checksum     binary SHA-256 checksum or null
+     * @param relocations  jar relocations or null
+     * @param isolatedLoad isolated load for this library
+     */
+    private Library(Collection<String> urls,
+                    Collection<String> repositories,
                     String id,
                     String groupId,
                     String artifactId,
@@ -109,6 +143,8 @@ public class Library {
         }
 
         this.path = path + ".jar";
+
+        this.repositories = repositories != null ? Collections.unmodifiableList(new LinkedList<>(repositories)) : Collections.emptyList();
         relocatedPath = hasRelocations() ? path + "-relocated.jar" : null;
         this.isolatedLoad = isolatedLoad;
     }
@@ -120,6 +156,15 @@ public class Library {
      */
     public Collection<String> getUrls() {
         return urls;
+    }
+
+    /**
+     * Gets the repositories URLs for this library.
+     *
+     * @return repositories URLs
+     */
+    public Collection<String> getRepositories() {
+        return repositories;
     }
 
     /**
@@ -271,6 +316,11 @@ public class Library {
         private final Collection<String> urls = new LinkedList<>();
 
         /**
+         * Repository URLs for this library
+         */
+        private final Collection<String> repositories = new LinkedList<>();
+
+        /**
          * The library ID
          */
         private String id;
@@ -318,6 +368,17 @@ public class Library {
          */
         public Builder url(String url) {
             urls.add(requireNonNull(url, "url"));
+            return this;
+        }
+
+        /**
+         * Adds a repository URL for this library.
+         *
+         * @param url repository URL
+         * @return this builder
+         */
+        public Builder repository(String url) {
+            repositories.add(requireNonNull(url, "repository"));
             return this;
         }
 
@@ -436,7 +497,7 @@ public class Library {
          * @return new library
          */
         public Library build() {
-            return new Library(urls, id, groupId, artifactId, version, classifier, checksum, relocations, isolatedLoad);
+            return new Library(urls, repositories, id, groupId, artifactId, version, classifier, checksum, relocations, isolatedLoad);
         }
     }
 }

--- a/core/src/main/java/net/byteflux/libby/LibraryManager.java
+++ b/core/src/main/java/net/byteflux/libby/LibraryManager.java
@@ -27,9 +27,11 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -203,28 +205,28 @@ public abstract class LibraryManager {
      * Adds the Maven Central repository.
      */
     public void addMavenCentral() {
-        addRepository("https://repo1.maven.org/maven2/");
+        addRepository(Repositories.MAVEN_CENTRAL);
     }
 
     /**
      * Adds the Sonatype OSS repository.
      */
     public void addSonatype() {
-        addRepository("https://oss.sonatype.org/content/groups/public/");
+        addRepository(Repositories.SONATYPE);
     }
 
     /**
      * Adds the Bintray JCenter repository.
      */
     public void addJCenter() {
-        addRepository("https://jcenter.bintray.com/");
+        addRepository(Repositories.JCENTER);
     }
 
     /**
      * Adds the JitPack repository.
      */
     public void addJitPack() {
-        addRepository("https://jitpack.io/");
+        addRepository(Repositories.JITPACK);
     }
 
     /**
@@ -235,12 +237,18 @@ public abstract class LibraryManager {
      * @return download URLs
      */
     public Collection<String> resolveLibrary(Library library) {
-        List<String> urls = new LinkedList<>(requireNonNull(library, "library").getUrls());
+        Set<String> urls = new LinkedHashSet<>(requireNonNull(library, "library").getUrls());
+
+        // Try from library-declared repos first
+        for (String repository : library.getRepositories()) {
+            urls.add(repository + library.getPath());
+        }
+
         for (String repository : getRepositories()) {
             urls.add(repository + library.getPath());
         }
 
-        return Collections.unmodifiableList(urls);
+        return Collections.unmodifiableSet(urls);
     }
 
     /**

--- a/core/src/main/java/net/byteflux/libby/Repositories.java
+++ b/core/src/main/java/net/byteflux/libby/Repositories.java
@@ -1,0 +1,31 @@
+package net.byteflux.libby;
+
+/**
+ * Class containing URLs of public repositories.
+ */
+public class Repositories {
+
+    /**
+     * Maven Central repository URL.
+     */
+    public static final String MAVEN_CENTRAL = "https://repo1.maven.org/maven2/";
+
+    /**
+     * Sonatype OSS repository URL.
+     */
+    public static final String SONATYPE = "https://oss.sonatype.org/content/groups/public/";
+
+    /**
+     * Bintray JCenter repository URL.
+     */
+    public static final String JCENTER = "https://jcenter.bintray.com/";
+
+    /**
+     * JitPack repository URL.
+     */
+    public static final String JITPACK = "https://jitpack.io/";
+
+    private Repositories() {
+        throw new UnsupportedOperationException("Private constructor");
+    }
+}

--- a/core/src/main/java/net/byteflux/libby/relocation/RelocationHelper.java
+++ b/core/src/main/java/net/byteflux/libby/relocation/RelocationHelper.java
@@ -2,6 +2,7 @@ package net.byteflux.libby.relocation;
 
 import net.byteflux.libby.Library;
 import net.byteflux.libby.LibraryManager;
+import net.byteflux.libby.Repositories;
 import net.byteflux.libby.classloader.IsolatedClassLoader;
 
 import java.io.File;
@@ -54,6 +55,7 @@ public class RelocationHelper {
                    .artifactId("asm-commons")
                    .version("9.2")
                    .checksum("vkzlMTiiOLtSLNeBz5Hzulzi9sqT7GLUahYqEnIl4KY=")
+                   .repository(Repositories.MAVEN_CENTRAL)
                    .build()
         ));
 
@@ -64,6 +66,7 @@ public class RelocationHelper {
                    .artifactId("asm")
                    .version("9.2")
                    .checksum("udT+TXGTjfOIOfDspCqqpkz4sxPWeNoDbwyzyhmbR/U=")
+                   .repository(Repositories.MAVEN_CENTRAL)
                    .build()
         ));
 
@@ -74,6 +77,7 @@ public class RelocationHelper {
                    .artifactId("jar-relocator")
                    .version("1.5")
                    .checksum("0D6eM99gKpEYFNDydgnto3Df0ygZGdRVqy5ahtj0oIs=")
+                   .repository(Repositories.MAVEN_CENTRAL)
                    .build()
         ));
 


### PR DESCRIPTION
Add the possibility to add a repository url directly in the Library instance instead of adding the repository into the LibraryManager.
Also add the Repositories class which contains some constants with the Maven Central, Sonatype, JCenter, and JitPack urls.