### PR TITLE
Add support for Java 16+ without --illegal-access=permit

### DIFF
--- a/bukkit/src/main/java/net/byteflux/libby/BukkitLibraryManager.java
+++ b/bukkit/src/main/java/net/byteflux/libby/BukkitLibraryManager.java
@@ -35,7 +35,7 @@ public class BukkitLibraryManager extends LibraryManager {
      */
     public BukkitLibraryManager(Plugin plugin, String directoryName) {
         super(new JDKLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath(), directoryName);
-        classLoader = new URLClassLoaderHelper((URLClassLoader) plugin.getClass().getClassLoader());
+        classLoader = new URLClassLoaderHelper((URLClassLoader) plugin.getClass().getClassLoader(), this);
     }
 
     /**

--- a/bungee/src/main/java/net/byteflux/libby/BungeeLibraryManager.java
+++ b/bungee/src/main/java/net/byteflux/libby/BungeeLibraryManager.java
@@ -35,7 +35,7 @@ public class BungeeLibraryManager extends LibraryManager {
      */
     public BungeeLibraryManager(Plugin plugin, String directoryName) {
         super(new JDKLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath(), directoryName);
-        classLoader = new URLClassLoaderHelper((URLClassLoader) plugin.getClass().getClassLoader());
+        classLoader = new URLClassLoaderHelper((URLClassLoader) plugin.getClass().getClassLoader(), this);
     }
 
     /**

--- a/core/src/main/java/net/byteflux/libby/LibraryManager.java
+++ b/core/src/main/java/net/byteflux/libby/LibraryManager.java
@@ -27,9 +27,11 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -63,7 +65,7 @@ public abstract class LibraryManager {
     /**
      * Maven repositories used to resolve artifacts
      */
-    private final List<String> repositories = new LinkedList<>();
+    private final Set<String> repositories = new HashSet<>();
 
     /**
      * Lazily-initialized relocation helper that uses reflection to call into

--- a/core/src/main/java/net/byteflux/libby/classloader/URLClassLoaderHelper.java
+++ b/core/src/main/java/net/byteflux/libby/classloader/URLClassLoaderHelper.java
@@ -1,10 +1,16 @@
 package net.byteflux.libby.classloader;
 
+import net.byteflux.libby.Library;
+import net.byteflux.libby.LibraryManager;
+
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -27,19 +33,38 @@ public class URLClassLoaderHelper {
     /**
      * Creates a new URL class loader helper.
      *
-     * @param classLoader the class loader to manage
+     * @param classLoader    the class loader to manage
+     * @param libraryManager the library manager used to download dependencies
      */
-    public URLClassLoaderHelper(URLClassLoader classLoader) {
+    public URLClassLoaderHelper(URLClassLoader classLoader, LibraryManager libraryManager) {
+        requireNonNull(libraryManager, "libraryManager");
         this.classLoader = requireNonNull(classLoader, "classLoader");
 
         try {
-            try {
-                // Java 9+
-                openUrlClassLoaderModule();
-            } catch (Exception ignored) {}
-
             addURLMethod = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
-            addURLMethod.setAccessible(true);
+
+            try {
+                openUrlClassLoaderModule();
+            } catch (Exception ignored) {
+            }
+
+            try {
+                addURLMethod.setAccessible(true);
+            } catch (Exception exception) {
+                // InaccessibleObjectException has been added in Java 9
+                if (exception.getClass().getName().equals("java.lang.reflect.InaccessibleObjectException")) {
+                    // It is Java 9+, try to open java.net package
+                    try {
+                        addOpensWithAgent(libraryManager);
+                        this.addURLMethod.setAccessible(true);
+                    } catch (Exception e) {
+                        System.err.println("Cannot access URLClassLoader#addURL(URL), if you are using Java 9+ try to add the following option to your java command: --add-opens java.base/java.net=ALL-UNNAMED");
+                        throw new RuntimeException("Cannot access URLClassLoader#addURL(URL)", e);
+                    }
+                } else {
+                    throw new RuntimeException("Cannot set accessible URLClassLoader#addURL(URL)", exception);
+                }
+            }
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
@@ -82,7 +107,7 @@ public class URLClassLoaderHelper {
         //
         // URLClassLoader.class.getModule().addOpens(
         //     URLClassLoader.class.getPackageName(),
-        //     ReflectionClassLoader.class.getModule()
+        //     URLClassLoaderHelper.class.getModule()
         // );
         //
         // We use reflection since we build against Java 8.
@@ -95,5 +120,56 @@ public class URLClassLoaderHelper {
         Object thisModule = getModuleMethod.invoke(URLClassLoaderHelper.class);
 
         addOpensMethod.invoke(urlClassLoaderModule, URLClassLoader.class.getPackage().getName(), thisModule);
+    }
+
+    private void addOpensWithAgent(LibraryManager libraryManager) throws Exception {
+
+        // To open URLClassLoader's module we need permissions.
+        // Try to add a java agent at runtime (specifically, ByteBuddy's agent) and use it to open the module,
+        // since java agents should have such permission.
+
+        // Download ByteBuddy's agent and load it through an IsolatedClassLoader
+        libraryManager.addMavenCentral();
+        IsolatedClassLoader isolatedClassLoader = new IsolatedClassLoader();
+        try {
+            isolatedClassLoader.addPath(libraryManager.downloadLibrary(
+                Library.builder()
+                       .groupId("net.bytebuddy")
+                       .artifactId("byte-buddy-agent")
+                       .version("1.12.1")
+                       .checksum("mcCtBT9cljUEniB5ESpPDYZMfVxEs1JRPllOiWTP+bM=")
+                       .build()
+            ));
+
+            Class<?> byteBuddyAgent = isolatedClassLoader.loadClass("net.bytebuddy.agent.ByteBuddyAgent");
+
+            // This is effectively calling:
+            //
+            // Instrumentation instrumentation = ByteBuddyAgent.install();
+            // instrumentation.redefineModule(
+            //     URLClassLoader.class.getModule(),
+            //     Collections.emptySet(),
+            //     Collections.emptyMap(),
+            //     Collections.singletonMap("java.net", Collections.singleton(getClass().getModule())),
+            //     Collections.emptySet(),
+            //     Collections.emptyMap()
+            // );
+            //
+            // For more information see https://docs.oracle.com/en/java/javase/16/docs/api/java.instrument/java/lang/instrument/Instrumentation.html
+            //
+            // We use reflection since we build against Java 8.
+
+            Object instrumentation = byteBuddyAgent.getDeclaredMethod("install").invoke(null);
+            Class<?> instrumentationClass = Class.forName("java.lang.instrument.Instrumentation");
+            Method redefineModule = instrumentationClass.getDeclaredMethod("redefineModule", Class.forName("java.lang.Module"), Set.class, Map.class, Map.class, Set.class, Map.class);
+            Method getModule = Class.class.getDeclaredMethod("getModule");
+            Map<String, Set<?>> toOpen = Collections.singletonMap("java.net", Collections.singleton(getModule.invoke(getClass())));
+            redefineModule.invoke(instrumentation, getModule.invoke(URLClassLoader.class), Collections.emptySet(), Collections.emptyMap(), toOpen, Collections.emptySet(), Collections.emptyMap());
+        } finally {
+            try {
+                isolatedClassLoader.close();
+            } catch (Exception ignored) {
+            }
+        }
     }
 }

--- a/nukkit/src/main/java/net/byteflux/libby/NukkitLibraryManager.java
+++ b/nukkit/src/main/java/net/byteflux/libby/NukkitLibraryManager.java
@@ -35,7 +35,7 @@ public class NukkitLibraryManager extends LibraryManager {
      */
     public NukkitLibraryManager(Plugin plugin, String directoryName) {
         super(new NukkitLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath(), directoryName);
-        classLoader = new URLClassLoaderHelper((URLClassLoader) plugin.getClass().getClassLoader());
+        classLoader = new URLClassLoaderHelper((URLClassLoader) plugin.getClass().getClassLoader(), this);
     }
 
     /**

--- a/sponge/src/main/java/net/byteflux/libby/SpongeLibraryManager.java
+++ b/sponge/src/main/java/net/byteflux/libby/SpongeLibraryManager.java
@@ -43,7 +43,7 @@ public class SpongeLibraryManager<T> extends LibraryManager {
     @Inject
     private SpongeLibraryManager(Logger logger, @ConfigDir(sharedRoot = false) Path dataDirectory, T plugin, String directoryName) {
         super(new SLF4JLogAdapter(logger), dataDirectory, directoryName);
-        classLoader = new URLClassLoaderHelper((URLClassLoader) requireNonNull(plugin, "plugin").getClass().getClassLoader());
+        classLoader = new URLClassLoaderHelper((URLClassLoader) requireNonNull(plugin, "plugin").getClass().getClassLoader(), this);
     }
 
     /**


### PR DESCRIPTION
Add support for Java 16+ without "--illegal-access=permit" or "--add-opens java.base/java.net=ALL-UNNAMED" parameters using the ByteBuddy agent to open the java.net package.
This also avoids duplicated repositories added by LibraryManager#addRepository(String).