### PR TITLE
Fix velocity and sponge support

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.5</version>
     </parent>
 
     <artifactId>libby-bukkit</artifactId>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.5</version>
     </parent>
 
     <artifactId>libby-bungee</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.5</version>
     </parent>
 
     <artifactId>libby-core</artifactId>

--- a/nukkit/pom.xml
+++ b/nukkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.5</version>
     </parent>
 
     <artifactId>libby-nukkit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.byteflux</groupId>
     <artifactId>libby</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/slf4j/pom.xml
+++ b/slf4j/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.5</version>
     </parent>
 
     <artifactId>libby-slf4j</artifactId>

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.5</version>
     </parent>
 
     <artifactId>libby-sponge</artifactId>

--- a/sponge/src/main/java/net/byteflux/libby/SpongeLibraryManager.java
+++ b/sponge/src/main/java/net/byteflux/libby/SpongeLibraryManager.java
@@ -26,18 +26,6 @@ public class SpongeLibraryManager<T> extends LibraryManager {
      * @param logger        the plugin logger
      * @param dataDirectory plugin's data directory
      * @param plugin        the plugin to manage
-     */
-    @Inject
-    private SpongeLibraryManager(Logger logger, @ConfigDir(sharedRoot = false) Path dataDirectory, T plugin) {
-        this(logger, dataDirectory, plugin, "lib");
-    }
-
-    /**
-     * Creates a new Sponge library manager.
-     *
-     * @param logger        the plugin logger
-     * @param dataDirectory plugin's data directory
-     * @param plugin        the plugin to manage
      * @param directoryName download directory name
      */
     @Inject

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.byteflux</groupId>
         <artifactId>libby</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.5</version>
     </parent>
 
     <artifactId>libby-velocity</artifactId>

--- a/velocity/src/main/java/net/byteflux/libby/VelocityLibraryManager.java
+++ b/velocity/src/main/java/net/byteflux/libby/VelocityLibraryManager.java
@@ -1,8 +1,6 @@
 package net.byteflux.libby;
 
-import com.google.inject.Inject;
 import com.velocitypowered.api.plugin.PluginManager;
-import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import net.byteflux.libby.logging.adapters.SLF4JLogAdapter;
 import org.slf4j.Logger;
 
@@ -34,16 +32,30 @@ public class VelocityLibraryManager<T> extends LibraryManager {
      * @param plugin        the plugin to manage
      * @param directoryName download directory name
      */
-    @Inject
-    private VelocityLibraryManager(Logger logger,
-                                   @DataDirectory Path dataDirectory,
-                                   PluginManager pluginManager,
-                                   T plugin,
-                                   String directoryName) {
+    public VelocityLibraryManager(Logger logger,
+                                  Path dataDirectory,
+                                  PluginManager pluginManager,
+                                  T plugin,
+                                  String directoryName) {
 
         super(new SLF4JLogAdapter(logger), dataDirectory, directoryName);
         this.pluginManager = requireNonNull(pluginManager, "pluginManager");
         this.plugin = requireNonNull(plugin, "plugin");
+    }
+
+    /**
+     * Creates a new Velocity library manager.
+     *
+     * @param logger        the plugin logger
+     * @param dataDirectory plugin's data directory
+     * @param pluginManager Velocity plugin manager
+     * @param plugin        the plugin to manage
+     */
+    public VelocityLibraryManager(Logger logger,
+                                  Path dataDirectory,
+                                  PluginManager pluginManager,
+                                  T plugin) {
+        this(logger, dataDirectory, pluginManager, plugin, "lib");
     }
 
     /**

--- a/velocity/src/main/java/net/byteflux/libby/VelocityLibraryManager.java
+++ b/velocity/src/main/java/net/byteflux/libby/VelocityLibraryManager.java
@@ -32,23 +32,6 @@ public class VelocityLibraryManager<T> extends LibraryManager {
      * @param dataDirectory plugin's data directory
      * @param pluginManager Velocity plugin manager
      * @param plugin        the plugin to manage
-     */
-    @Inject
-    private VelocityLibraryManager(Logger logger,
-                                   @DataDirectory Path dataDirectory,
-                                   PluginManager pluginManager,
-                                   T plugin) {
-
-        this(logger, dataDirectory, pluginManager, plugin, "lib");
-    }
-
-    /**
-     * Creates a new Velocity library manager.
-     *
-     * @param logger        the plugin logger
-     * @param dataDirectory plugin's data directory
-     * @param pluginManager Velocity plugin manager
-     * @param plugin        the plugin to manage
      * @param directoryName download directory name
      */
     @Inject


### PR DESCRIPTION
Injection is not possible with multiple constructors meaning the current implementation fails and isn't really necessary in this use case. Further, the current method will lead to countless https://github.com/google/guice/wiki/CAN_NOT_PROXY_CLASS errors as it requires a T type (plugin instance) which you can't directly reference staticly as that creates a circular dependency which can't be proxied when injecting.

I've changed the velocity manager here to allow direct instantiation rather than runtime injection. I've also removed one constructor from the sponge one (which has a similar problem) to fix the https://github.com/google/guice/wiki/TOO_MANY_CONSTRUCTORS that occurs with that.

Here's how you get a VelocityLibraryManager now:
```java
VelocityLibraryManager<VelocityPlugin> manager = new VelocityLibraryManager<>(logger, dataDirectory, getProxyServer().getPluginManager(), getInstance(), "lib");
```
where
`logger` -> your SL4J instance
`dataDirectory` -> your `@DataDirectory` already retrievable through injection
`VelocityPlugin` -> your velocity plugin