### PR TITLE
Add support for the new Paper Plugins.

### DIFF
--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>net.byteflux</groupId>
+        <artifactId>libby</artifactId>
+        <version>1.1.5</version>
+    </parent>
+
+    <artifactId>libby-paper</artifactId>
+
+    <repositories>
+        <repository>
+            <id>paper</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.byteflux</groupId>
+            <artifactId>libby-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.19-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/paper/src/main/java/net/byteflux/libby/PaperLibraryManager.java
+++ b/paper/src/main/java/net/byteflux/libby/PaperLibraryManager.java
@@ -11,7 +11,8 @@ import java.nio.file.Path;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A runtime dependency manager for Bukkit plugins.
+ * A runtime dependency manager for Paper Plugins. (Not to be confused with bukkit plugins loaded on paper)
+ * See: <a href="https://docs.papermc.io/paper/dev/getting-started/paper-plugins">Paper docs</a>
  */
 public class PaperLibraryManager extends LibraryManager {
     /**
@@ -20,7 +21,7 @@ public class PaperLibraryManager extends LibraryManager {
     private final URLClassLoaderHelper classLoader;
 
     /**
-     * Creates a new Bukkit library manager.
+     * Creates a new Paper library manager.
      *
      * @param plugin the plugin to manage
      */
@@ -29,7 +30,7 @@ public class PaperLibraryManager extends LibraryManager {
     }
 
     /**
-     * Creates a new Bukkit library manager.
+     * Creates a new Paper library manager.
      *
      * @param plugin the plugin to manage
      * @param directoryName download directory name
@@ -73,7 +74,7 @@ public class PaperLibraryManager extends LibraryManager {
     }
 
     /**
-     * Adds a file to the Bukkit plugin's classpath.
+     * Adds a file to the Paper plugin's classpath.
      *
      * @param file the file to add
      */

--- a/paper/src/main/java/net/byteflux/libby/PaperLibraryManager.java
+++ b/paper/src/main/java/net/byteflux/libby/PaperLibraryManager.java
@@ -1,0 +1,84 @@
+package net.byteflux.libby;
+
+import net.byteflux.libby.classloader.URLClassLoaderHelper;
+import net.byteflux.libby.logging.adapters.JDKLogAdapter;
+import org.bukkit.plugin.Plugin;
+
+import java.lang.reflect.Field;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A runtime dependency manager for Bukkit plugins.
+ */
+public class PaperLibraryManager extends LibraryManager {
+    /**
+     * Plugin classpath helper
+     */
+    private final URLClassLoaderHelper classLoader;
+
+    /**
+     * Creates a new Bukkit library manager.
+     *
+     * @param plugin the plugin to manage
+     */
+    public PaperLibraryManager(Plugin plugin) {
+        this(plugin, "lib");
+    }
+
+    /**
+     * Creates a new Bukkit library manager.
+     *
+     * @param plugin the plugin to manage
+     * @param directoryName download directory name
+     */
+    public PaperLibraryManager(Plugin plugin, String directoryName) {
+        super(new JDKLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath(), directoryName);
+
+        ClassLoader cl = plugin.getClass().getClassLoader();
+        Class<?> paperClClazz;
+
+        try {
+             paperClClazz = Class.forName("io.papermc.paper.plugin.entrypoint.classloader.PaperPluginClassLoader");
+        } catch (ClassNotFoundException e) {
+            System.err.println("PaperPluginClassLoader not found, are you using Paper 1.19.3+?");
+            throw new RuntimeException(e);
+        }
+
+        if (!paperClClazz.isAssignableFrom(cl.getClass())) {
+            throw new RuntimeException("Plugin classloader is not a PaperPluginClassLoader, are you using paper-plugin.yml?");
+        }
+
+        Field libraryLoaderField;
+
+        try {
+            libraryLoaderField = paperClClazz.getDeclaredField("libraryLoader");
+        } catch (NoSuchFieldException e) {
+            System.err.println("Cannot find libraryLoader field in PaperPluginClassLoader, please open a bug report.");
+            throw new RuntimeException(e);
+        }
+
+        libraryLoaderField.setAccessible(true);
+
+        URLClassLoader libraryLoader;
+        try {
+            libraryLoader = (URLClassLoader) libraryLoaderField.get(cl);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e); // Should never happen
+        }
+
+        classLoader = new URLClassLoaderHelper(libraryLoader, this);
+    }
+
+    /**
+     * Adds a file to the Bukkit plugin's classpath.
+     *
+     * @param file the file to add
+     */
+    @Override
+    protected void addToClasspath(Path file) {
+        classLoader.addToClasspath(file);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>slf4j</module>
         <module>sponge</module>
         <module>velocity</module>
+        <module>paper</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This PR adds PaperLibraryManager which can be used to load dependencies in plugins loaded via the new Paper API (https://docs.papermc.io/paper/dev/getting-started/paper-plugins)
The BukkitLibraryManager does not work under Paper Plugins.