### PR TITLE
Bump jar-relocator to 1.7 due to weird relocating issues with 1.5

### DIFF
--- a/core/src/main/java/net/byteflux/libby/relocation/RelocationHelper.java
+++ b/core/src/main/java/net/byteflux/libby/relocation/RelocationHelper.java
@@ -75,8 +75,8 @@ public class RelocationHelper {
             Library.builder()
                    .groupId("me.lucko")
                    .artifactId("jar-relocator")
-                   .version("1.5")
-                   .checksum("0D6eM99gKpEYFNDydgnto3Df0ygZGdRVqy5ahtj0oIs=")
+                   .version("1.7")
+                   .checksum("b30RhOF6kHiHl+O5suNLh/+eAr1iOFEFLXhwkHHDu4I=")
                    .repository(Repositories.MAVEN_CENTRAL)
                    .build()
         ));


### PR DESCRIPTION
If this gets merged, could you please bump the libby version, because the current version (with jar-relocator 1.5) makes my plugin incompatible with LibertyBans? PR https://github.com/lucko/jar-relocator/pull/4 which got merged in jar-relocator 1.6 fixes my issue.