### PR TITLE
Fetch libraries, repositories etc. from a JSON file.

### DIFF
--- a/bukkit/src/main/java/net/byteflux/libby/BukkitLibraryManager.java
+++ b/bukkit/src/main/java/net/byteflux/libby/BukkitLibraryManager.java
@@ -4,6 +4,7 @@ import net.byteflux.libby.classloader.URLClassLoaderHelper;
 import net.byteflux.libby.logging.adapters.JDKLogAdapter;
 import org.bukkit.plugin.Plugin;
 
+import java.io.InputStream;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 
@@ -17,6 +18,7 @@ public class BukkitLibraryManager extends LibraryManager {
      * Plugin classpath helper
      */
     private final URLClassLoaderHelper classLoader;
+    private final Plugin plugin;
 
     /**
      * Creates a new Bukkit library manager.
@@ -36,6 +38,7 @@ public class BukkitLibraryManager extends LibraryManager {
     public BukkitLibraryManager(Plugin plugin, String directoryName) {
         super(new JDKLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath(), directoryName);
         classLoader = new URLClassLoaderHelper((URLClassLoader) plugin.getClass().getClassLoader(), this);
+        this.plugin = plugin;
     }
 
     /**
@@ -46,5 +49,10 @@ public class BukkitLibraryManager extends LibraryManager {
     @Override
     protected void addToClasspath(Path file) {
         classLoader.addToClasspath(file);
+    }
+
+    @Override
+    protected InputStream getPluginResourceAsInputStream(String path) {
+        return plugin.getResource(path);
     }
 }

--- a/bungee/src/main/java/net/byteflux/libby/BungeeLibraryManager.java
+++ b/bungee/src/main/java/net/byteflux/libby/BungeeLibraryManager.java
@@ -4,6 +4,7 @@ import net.byteflux.libby.classloader.URLClassLoaderHelper;
 import net.byteflux.libby.logging.adapters.JDKLogAdapter;
 import net.md_5.bungee.api.plugin.Plugin;
 
+import java.io.InputStream;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 
@@ -17,6 +18,8 @@ public class BungeeLibraryManager extends LibraryManager {
      * Plugin classpath helper
      */
     private final URLClassLoaderHelper classLoader;
+
+    private final Plugin plugin;
 
     /**
      * Creates a new Bungee library manager.
@@ -36,6 +39,12 @@ public class BungeeLibraryManager extends LibraryManager {
     public BungeeLibraryManager(Plugin plugin, String directoryName) {
         super(new JDKLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath(), directoryName);
         classLoader = new URLClassLoaderHelper((URLClassLoader) plugin.getClass().getClassLoader(), this);
+        this.plugin = plugin;
+    }
+
+    @Override
+    protected InputStream getPluginResourceAsInputStream(String path) throws UnsupportedOperationException {
+        return plugin.getResourceAsStream(path);
     }
 
     /**

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,6 +40,35 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.grack.nanojson</pattern>
+                                    <shadedPattern>net.byteflux.libby.nanojson</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.grack</groupId>
+            <artifactId>nanojson</artifactId>
+            <version>1.7</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/core/src/main/java/net/byteflux/libby/LibraryManager.java
+++ b/core/src/main/java/net/byteflux/libby/LibraryManager.java
@@ -1,5 +1,10 @@
 package net.byteflux.libby;
 
+import com.grack.nanojson.JsonArray;
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+import com.grack.nanojson.JsonParserException;
+import com.grack.nanojson.JsonReader;
 import net.byteflux.libby.classloader.IsolatedClassLoader;
 import net.byteflux.libby.logging.LogLevel;
 import net.byteflux.libby.logging.Logger;
@@ -30,11 +35,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -91,7 +98,6 @@ public abstract class LibraryManager {
      *
      * @param logAdapter    plugin logging adapter
      * @param dataDirectory plugin's data directory
-     *
      * @deprecated Use {@link LibraryManager#LibraryManager(LogAdapter, Path, String)}
      */
     @Deprecated
@@ -123,7 +129,7 @@ public abstract class LibraryManager {
      * Adds a file to the isolated class loader
      *
      * @param library the library to add
-     * @param file the file to add
+     * @param file    the file to add
      */
     protected void addToIsolatedClasspath(Library library, Path file) {
         IsolatedClassLoader classLoader;
@@ -277,9 +283,9 @@ public abstract class LibraryManager {
      * Resolves the URL of the artifact of a snapshot library.
      *
      * @param repository The repository to query for snapshot information
-     * @param library The library
+     * @param library    The library
      * @return The URl of the artifact of a snapshot library or null if no information could be gathered from the
-     *         provided repository
+     * provided repository
      */
     private String resolveSnapshot(String repository, Library library) {
         String url = requireNonNull(repository, "repository") + requireNonNull(library, "library").getPartialPath() + "maven-metadata.xml";
@@ -315,9 +321,9 @@ public abstract class LibraryManager {
      * library's maven-metadata.xml.
      *
      * @param inputStream The InputStream opened to the library's maven-metadata.xml
-     * @param library The library
+     * @param library     The library
      * @return The URl of the artifact of a snapshot library or null if no information could be gathered from the
-     *         provided inputStream
+     * provided inputStream
      * @throws IOException If any IO errors occur
      */
     private String getURLFromMetadata(InputStream inputStream, Library library) throws IOException {
@@ -592,5 +598,137 @@ public abstract class LibraryManager {
         } else {
             addToClasspath(file);
         }
+    }
+
+    /**
+     * Loads multiple libraries into the plugin's classpath.
+     *
+     * @param libraries the libraries to load
+     * @see #loadLibrary(Library)
+     */
+    public void loadLibraries(Library... libraries) {
+        for (Library library : libraries) {
+            loadLibrary(library);
+        }
+    }
+
+    /**
+     * Configures the current library manager from a json file.
+     * <p>
+     * This includes:
+     * <ul>
+     *     <li>Adding repositories</li>
+     *     <li>Adding and relocating libraries</li>
+     * </ul>
+     *
+     * @param data The json file
+     * @throws JsonParserException If the json file is corrupted
+     */
+    public void configureFromJSON(InputStream data) throws JsonParserException {
+        JsonObject root = JsonParser.object().from(data);
+
+        // The version value must be included in the JSON file and match the version of the parser
+        int version = root.getInt("version", -1);
+
+        if (version != 0) {
+            throw new IllegalArgumentException("The json file is version " + version + " but this version of libby only supports version 0");
+        }
+
+        // The repositories don't have to be included in the JSON file
+        // If they are, they must be an array of strings representing the repository URLs
+        JsonArray repositories = root.getArray("repositories");
+        if (repositories != null) {
+            for (int i = 0; i < repositories.size(); i++) {
+                addRepository(repositories.getString(i));
+            }
+        }
+
+        Set<Relocation> parsedRelocations = new HashSet<>();
+
+        // The relocations don't have to be included in the JSON file
+        // If they are, they must be an object with keys representing the original class name and values representing the relocated class name
+        JsonObject relocations = root.getObject("relocations");
+
+        for (String from : relocations.keySet()) {
+            parsedRelocations.add(new Relocation(from, relocations.getString(from)));
+        }
+
+        // The libraries don't have to be included in the JSON file
+        // If they are, they must be an array of objects that include the following properties:
+        // - group: The groupId of the library
+        // - name: The artifactId of the library
+        // - version: The version of the library
+        // Optional properties:
+        // - checksum: The SHA-256 checksum of the library, must be a base64 encoded string and may only be included if the library is a JAR.
+        JsonArray libraries = root.getArray("libraries");
+
+        if (libraries != null) {
+            for (int i = 0; i < libraries.size(); i++) {
+                JsonObject library = libraries.getObject(i);
+                Library.Builder libraryBuilder = Library.builder();
+
+                String groupId = library.getString("group");
+
+                if (groupId == null) {
+                    throw new IllegalArgumentException("The group property is required for all libraries");
+                }
+
+                String artifactId = library.getString("name");
+
+                if (artifactId == null) {
+                    throw new IllegalArgumentException("The name property is required for all libraries");
+                }
+
+                String artifactVersion = library.getString("version");
+
+                if (artifactVersion == null) {
+                    throw new IllegalArgumentException("The version property is required for all libraries");
+                }
+
+                libraryBuilder
+                    .groupId(groupId)
+                    .artifactId(artifactId)
+                    .version(artifactVersion);
+
+                String checksum = library.getString("checksum");
+
+                if (checksum != null) {
+                    libraryBuilder.checksum(checksum);
+                }
+
+                // We will just apply the relocations to all libraries. While it's not the most efficient, it's the easiest to implement
+                for (Relocation relocation : parsedRelocations) {
+                    libraryBuilder.relocate(relocation);
+                }
+
+                loadLibrary(libraryBuilder.build());
+            }
+        }
+    }
+
+    /**
+     * Configures the current library manager from a libby.json file in the plugin classpath.
+     *
+     * @see #configureFromJSON(InputStream)
+     */
+    public void configureFromJSON() {
+        try {
+            configureFromJSON(getPluginResourceAsInputStream("libby.json"));
+        } catch (JsonParserException e) {
+            logger.error("Your libby.json file is corrupted!", e);
+        } catch (UnsupportedOperationException e) {
+            logger.error("Loading resources from the plugin file is not implemented on this platform.", e);
+        }
+    }
+
+    /**
+     * Gets an input stream for a resource in the plugin file.
+     *
+     * @param path the path to the resource
+     * @return input stream for the resource
+     * @throws UnsupportedOperationException if the platform doesn't implement loading resources from the plugin file
+     */
+    protected InputStream getPluginResourceAsInputStream(String path) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException("Loading resources from the plugin file is not supported on this platform.");
     }
 }

--- a/nukkit/src/main/java/net/byteflux/libby/NukkitLibraryManager.java
+++ b/nukkit/src/main/java/net/byteflux/libby/NukkitLibraryManager.java
@@ -4,6 +4,7 @@ import cn.nukkit.plugin.Plugin;
 import net.byteflux.libby.classloader.URLClassLoaderHelper;
 import net.byteflux.libby.logging.adapters.NukkitLogAdapter;
 
+import java.io.InputStream;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 
@@ -17,6 +18,8 @@ public class NukkitLibraryManager extends LibraryManager {
      * Plugin classpath helper
      */
     private final URLClassLoaderHelper classLoader;
+
+    private final Plugin plugin;
 
     /**
      * Creates a new Nukkit library manager.
@@ -36,6 +39,7 @@ public class NukkitLibraryManager extends LibraryManager {
     public NukkitLibraryManager(Plugin plugin, String directoryName) {
         super(new NukkitLogAdapter(requireNonNull(plugin, "plugin").getLogger()), plugin.getDataFolder().toPath(), directoryName);
         classLoader = new URLClassLoaderHelper((URLClassLoader) plugin.getClass().getClassLoader(), this);
+        this.plugin = plugin;
     }
 
     /**
@@ -46,5 +50,10 @@ public class NukkitLibraryManager extends LibraryManager {
     @Override
     protected void addToClasspath(Path file) {
         classLoader.addToClasspath(file);
+    }
+
+    @Override
+    protected InputStream getPluginResourceAsInputStream(String path) throws UnsupportedOperationException {
+        return plugin.getResource(path);
     }
 }

--- a/paper/src/main/java/net/byteflux/libby/PaperLibraryManager.java
+++ b/paper/src/main/java/net/byteflux/libby/PaperLibraryManager.java
@@ -4,6 +4,7 @@ import net.byteflux.libby.classloader.URLClassLoaderHelper;
 import net.byteflux.libby.logging.adapters.JDKLogAdapter;
 import org.bukkit.plugin.Plugin;
 
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
@@ -19,6 +20,8 @@ public class PaperLibraryManager extends LibraryManager {
      * Plugin classpath helper
      */
     private final URLClassLoaderHelper classLoader;
+
+    private final Plugin plugin;
 
     /**
      * Creates a new Paper library manager.
@@ -71,6 +74,7 @@ public class PaperLibraryManager extends LibraryManager {
         }
 
         classLoader = new URLClassLoaderHelper(libraryLoader, this);
+        this.plugin = plugin;
     }
 
     /**
@@ -81,5 +85,10 @@ public class PaperLibraryManager extends LibraryManager {
     @Override
     protected void addToClasspath(Path file) {
         classLoader.addToClasspath(file);
+    }
+
+    @Override
+    protected InputStream getPluginResourceAsInputStream(String path) throws UnsupportedOperationException {
+        return plugin.getResource(path);
     }
 }

--- a/velocity/src/main/java/net/byteflux/libby/VelocityLibraryManager.java
+++ b/velocity/src/main/java/net/byteflux/libby/VelocityLibraryManager.java
@@ -4,6 +4,7 @@ import com.velocitypowered.api.plugin.PluginManager;
 import net.byteflux.libby.logging.adapters.VelocityLogAdapter;
 import org.slf4j.Logger;
 
+import java.io.InputStream;
 import java.nio.file.Path;
 
 import static java.util.Objects.requireNonNull;
@@ -66,5 +67,10 @@ public class VelocityLibraryManager<T> extends LibraryManager {
     @Override
     protected void addToClasspath(Path file) {
         pluginManager.addToClasspath(plugin, file);
+    }
+
+    @Override
+    protected InputStream getPluginResourceAsInputStream(String path) throws UnsupportedOperationException {
+        return getClass().getClassLoader().getResourceAsStream(path);
     }
 }


### PR DESCRIPTION
Currently, the only way to configure Libby is by using the relevant methods on LibraryManager. While this is great, Libby currently lacks some data-driven approach. 
This PR aims to do the following things only by using a JSON file:
- Download dependencies, validate their checksums, and relocate them
- Add custom repositories

# How could this be used
While this may sound like bloat initially, it has very lucrative uses.
## Build system plugins
This PR (assuming a relevant build system plugin exists) allows specifying which dependencies should be downloaded at runtime directly in the build system configuration (pom.xml, build.gradle, etc.)
Due to the nature of these systems, they can easily resolve transitive dependencies and calculate the checksum. 
This puts an end to writing boilerplate code and trying to guess dependencies that are required for a dependency to function (and thus partially addresses #18). 

### Gradle
To demonstrate the usefulness of this feature, [I've created a plugin that aims to accomplish this. ](https://github.com/kyngs/libby-gradle-plugin)

I'll take my plugin as an example:
[An 100+LOC hard to maintain file which includes the dependencies for my plugin](https://github.com/kyngs/LibreLogin/blob/5d24862d0f99d3fd1f83ce63a34df36ad4f6c57a/Plugin/src/main/java/xyz/kyngs/librelogin/common/util/DependencyUtil.java#L18-L178), can (using this gradle plugin) be rewritten only by modifying a few lines in the `build.gradle` file:
```gradle
dependencies {
    //MySQL
    libby 'org.mariadb.jdbc:mariadb-java-client:3.2.0'
    libby 'com.zaxxer:HikariCP:5.0.1'

    //SQLite
    libby 'org.xerial:sqlite-jdbc:3.43.0.0'

    //PostgreSQL
    libby 'org.postgresql:postgresql:42.6.0'
    
     //Utils
    libby 'com.github.ben-manes.caffeine:caffeine:3.1.8'
    libby 'org.spongepowered:configurate-hocon:4.1.2'
    libby 'at.favre.lib:bcrypt:0.10.2'
    libby 'dev.samstevens.totp:totp:1.7.1'
    libby 'org.bouncycastle:bcprov-jdk18on:1.76'
    libby 'org.apache.commons:commons-email:1.5'
    libby 'net.kyori:adventure-text-minimessage:4.14.0'
}
```

And then calling a simple bootstrap method:
```java
libraryManager.configureFromJSON();
```

### Maven (and other systems)
The same thing can be accomplished with any build system which supports plugins. 

## Other usages
Considering this PR allows to load the configuration from any JSON file (not only the libby.json file in the plugin JAR), it probably can be used for other things.

# Technical info
**This patch does not break the API in any way or matter**

Considering there's really no way to document a JSON, I've documented the format in the `LibraryManager#configureFromJSON` method. 

Currently, Libby does not bundle any JSON library. To keep the size as small as possible, I've decided to choose the fantastic NanoJSON library which only adds about 25kB to the final JAR.

I've tested both the plugin and this PR by converting my plugin to this approach.

# Finally
While I think the implementation is good as-is, I would love to hear some feedback (positive, or negative). 