### PR TITLE
Add configurable cache expiry

### DIFF
--- a/core/src/main/java/net/byteflux/libby/Library.java
+++ b/core/src/main/java/net/byteflux/libby/Library.java
@@ -327,6 +327,7 @@ public class Library {
 
     /**
      * The duration of time to keep the cached (downloaded) library for
+     *
      * @return the duration
      */
     public Duration getCacheDuration() {


### PR DESCRIPTION
o/

This pull request addresses two key issues with snapshots not being cached:

1. Plugins using Libby, especially on test servers and or those with a large userbase can generate excessive bandwidth for package repositories.
2. It also slows down server configuration and plugin development, especially on slow internet connections.

This pull aims to mitigate both issues while offering additional flexibility if needed.

Changes:
- added cacheDuration(Duration) to Library.Builder
- Snapshots are now cached for 1 day by default

A `.timestamp` file is used to track the age, rather than relying on file creation dates, which are platform-dependent.

_Think of the poor package repositories!_